### PR TITLE
BUG: Ensure dask[distributed] requires python>=3.9.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     author='Lalith Kumar Shiyam Sundar | Sebastian Gutschmayer',
     author_email='Lalith.shiyamsundar@meduniwien.ac.at',
     description='An AI-inference engine for 3D clinical and preclinical whole-body segmentation tasks',
-    python_requires='>=3.9',
+    python_requires='>=3.9.2',
     long_description='mooseZ is an AI-inference engine based on nnUNet, designed for 3D clinical and preclinical'
                      ' whole-body segmentation tasks. It serves models tailored towards different modalities such'
                      ' as PET, CT, and MR. mooseZ provides fast and accurate segmentation results, making it a '

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='moosez',
-    version='2.2.30',
+    version='2.2.31',
     author='Lalith Kumar Shiyam Sundar | Sebastian Gutschmayer',
     author_email='Lalith.shiyamsundar@meduniwien.ac.at',
     description='An AI-inference engine for 3D clinical and preclinical whole-body segmentation tasks',


### PR DESCRIPTION
**Description:**

This PR addresses the issue where the `dask[distributed]` package was mistakenly set to require Python 3.9.0. Given the specific requirements of the package, it's imperative to ensure compatibility with Python 3.9.2 or later.

**Changes:**

- Updated the `python_requires` field in `setup.py` to specify a minimum Python version of 3.9.2.

**Reason for Change:**

Certain functionalities or dependencies within `dask[distributed]` are either incompatible or untested with Python versions earlier than 3.9.2. By enforcing this version requirement, we aim to prevent potential inconsistencies or issues for users who are utilizing older Python versions.

**Testing:**

- [X] Ensure that the package installation fails for Python versions below 3.9.2.

- [x] Confirm that the package installs successfully and operates as expected on Python 3.9.2 and newer.

**Related Issue:**

- https://github.com/QIMP-Team/MOOSE/issues/59