### PR TITLE
Fixed naming issue when dicom header Series Number is None

### DIFF
--- a/moosez/image_conversion.py
+++ b/moosez/image_conversion.py
@@ -197,10 +197,10 @@ def create_dicom_lookup(dicom_dir: str) -> dict:
         if is_dicom_file(full_path):
             ds = pydicom.dcmread(full_path)
 
-            series_number = ds.SeriesNumber if 'SeriesNumber' in ds else None
-            series_description = ds.SeriesDescription if 'SeriesDescription' in ds else None
-            sequence_name = ds.SequenceName if 'SequenceName' in ds else None
-            protocol_name = ds.ProtocolName if 'ProtocolName' in ds else None
+            series_number = ds.SeriesNumber if 'SeriesNumber' in ds else False
+            series_description = ds.SeriesDescription if 'SeriesDescription' in ds else False
+            sequence_name = ds.SequenceName if 'SequenceName' in ds else False
+            protocol_name = ds.ProtocolName if 'ProtocolName' in ds else False
             series_instance_UID = ds.SeriesInstanceUID if 'SeriesInstanceUID' in ds else None
 
             if ds.Modality == 'PT':
@@ -208,13 +208,13 @@ def create_dicom_lookup(dicom_dir: str) -> dict:
             else:
                 modality = ds.Modality
 
-            if series_number is not None:
+            if series_number is not False:
                 base_filename = remove_accents(series_number)
-                if series_description is not None:
+                if series_description is not False:
                     anticipated_filename = f"{base_filename}_{remove_accents(series_description)}.nii"
-                elif sequence_name is not None:
+                elif sequence_name is not False:
                     anticipated_filename = f"{base_filename}_{remove_accents(sequence_name)}.nii"
-                elif protocol_name is not None:
+                elif protocol_name is not False:
                     anticipated_filename = f"{base_filename}_{remove_accents(protocol_name)}.nii"
             else:
                 anticipated_filename = f"{remove_accents(series_instance_UID)}.nii"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='moosez',
-    version='2.2.34',
+    version='2.2.35',
     author='Lalith Kumar Shiyam Sundar | Sebastian Gutschmayer',
     author_email='Lalith.shiyamsundar@meduniwien.ac.at',
     description='An AI-inference engine for 3D clinical and preclinical whole-body segmentation tasks',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='moosez',
-    version='2.2.33',
+    version='2.2.34',
     author='Lalith Kumar Shiyam Sundar | Sebastian Gutschmayer',
     author_email='Lalith.shiyamsundar@meduniwien.ac.at',
     description='An AI-inference engine for 3D clinical and preclinical whole-body segmentation tasks',


### PR DESCRIPTION
Previously when Series Number didn't exist it was set to None. This created a conflict when the value of Series Number is None. To fix this Series Number is now set to False when it doesn't exist.