### PR TITLE
logging fix/adjustment

### DIFF
--- a/moosez/moosez.py
+++ b/moosez/moosez.py
@@ -40,12 +40,10 @@ from moosez.image_processing import ImageResampler
 from moosez.nnUNet_custom_trainer.utility import add_custom_trainers_to_local_nnunetv2
 from moosez.resources import MODELS, AVAILABLE_MODELS
 
-logging.basicConfig(format='%(asctime)s %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s', level=logging.INFO,
-                    filename=datetime.now().strftime('moosez-v.2.0.0.%H-%M-%d-%m-%Y.log'),
-                    filemode='w')
-
 
 def main():
+    logging.basicConfig(format='%(asctime)s %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s', level=logging.INFO,
+                        filename=datetime.now().strftime('moosez-v.2.0.0.%H-%M-%d-%m-%Y.log'), filemode='w')
     colorama.init()
 
     # Argument parser

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='moosez',
-    version='2.3.1',
+    version='2.3.2',
     author='Lalith Kumar Shiyam Sundar | Sebastian Gutschmayer',
     author_email='Lalith.shiyamsundar@meduniwien.ac.at',
     description='An AI-inference engine for 3D clinical and preclinical whole-body segmentation tasks',


### PR DESCRIPTION
This PR Moves the `logging` setup from outside the `main()` in `moosez.py` to inside the `main()` function. This ensures that the `logging` file is only set up when `moosez` is run via the terminal and not when it is used as a package.

Also, this raises the `moosez` version to 2.3.2 in the `setup.py`.