### PR TITLE
FIX: broadcast error while exporting segmentations from nnU-Net | #186

### DIFF
--- a/moosez/predict.py
+++ b/moosez/predict.py
@@ -46,18 +46,18 @@ def initialize_predictor(model: models.Model, accelerator: str) -> nnUNetPredict
 
 @dask.delayed
 def process_case(preprocessor, chunk: np.ndarray, chunk_properties: Dict, predictor: nnUNetPredictor, location: Tuple) -> Dict:
-    data, seg = preprocessor.run_case_npy(chunk,
-                                          None,
-                                          chunk_properties,
-                                          predictor.plans_manager,
-                                          predictor.configuration_manager,
-                                          predictor.dataset_json)
+    data, seg, prop = preprocessor.run_case_npy(chunk,
+                                                None,
+                                                chunk_properties,
+                                                predictor.plans_manager,
+                                                predictor.configuration_manager,
+                                                predictor.dataset_json)
 
     data_tensor = torch.from_numpy(data).contiguous()
     if predictor.device == "cuda":
         data_tensor = data_tensor.pin_memory()
 
-    return {'data': data_tensor, 'data_properties': chunk_properties, 'ofile': None, 'location': location}
+    return {'data': data_tensor, 'data_properties': prop, 'ofile': None, 'location': location}
 
 
 def preprocessing_iterator_from_array(image_array: np.ndarray, image_properties: Dict, predictor: nnUNetPredictor, output_manager: system.OutputManager) -> Tuple[Iterator, List[Dict]]:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='moosez',
-    version="3.0.15",
+    version="3.0.16",
     author='Lalith Kumar Shiyam Sundar | Sebastian Gutschmayer | Manuel Pires',
     author_email='Lalith.shiyamsundar@meduniwien.ac.at',
     description='An AI-inference engine for 3D clinical and preclinical whole-body segmentation tasks',
@@ -33,14 +33,11 @@ setup(
     install_requires=[
         'torch',
         'SimpleITK',
-        'acvl-utils==0.2',
         'nnunetv2',
         'halo~=0.0.31',
         'pydicom~=2.2.2',
         'argparse~=1.4.0',
         'numpy<2.0',
-        'mpire~=2.3.3',
-        'openpyxl~=3.0.9',
         'pyfiglet~=0.8.post1',
         'natsort~=8.1.0',
         'colorama~=0.4.6',


### PR DESCRIPTION
This addresses Issue #186. Recently, the segmentation export of nnU-Net sometimes encountered rounding issues, leading to `ValueError: could not broadcast input array from shape (x0,y0,z0) into shape (x1,y1,z1)`. This was fixed earlier this year in February with nnU-Net 2.6.0. However, moosez's setup limited the installation of nnU-Net to be < 2.6.0 due to the acvl-utils==0.2 requirement. 

Optimized package requirements and adjusted iterator creation in light of the latest nnU-Net version.

setup.py
- elevated version to 3.0.16
- removed the following requirements:
  - acvl-utils==0.2 (this enables the latest install of nnU-Net)
  - mpire~=2.3.3 (mpire is not used anymore)
  - openpyxl~=3.0.9 (not needed, as only CSV files are written)

predict.py
- adjusted the function process_case() to correctly return data, seg, and prop from run_case_npy(), a recent change in nnU-Net's latest version (see [here](https://github.com/MIC-DKFZ/nnUNet/commit/ce7edfa0baf22509ac36d6d5708278e1b23c6df9#diff-4074b4e1ce1ba9855887ce3987ab0374362f11080939861a5fb33e159799223dR92)).