### PR TITLE
Fixed issue when a model with organs without SNOMED lookup was picked | #207

### DIFF
--- a/moosez/models.py
+++ b/moosez/models.py
@@ -309,8 +309,10 @@ class Model:
     def organ_indices_to_json(self, directory_path: str):
         organ_indices_mappings = {}
         for intensity, organ_name in self.organ_indices.items():
-            organ_indices_mappings[intensity] = {"name": organ_name,
-                                                 "SNOMED": SNOMED.moose_to_snomed[organ_name]}
+            organ_indices_mappings[intensity] = {"name": organ_name}
+            if organ_name in SNOMED.moose_to_snomed:
+                organ_indices_mappings[intensity]["SNOMED"] = SNOMED.moose_to_snomed[organ_name]
+
         file_path = os.path.join(directory_path, f"{self.multilabel_prefix}organ_indices.json")
         with open(file_path, "w") as organ_indices_json_file:
             json.dump({"organ_indices": organ_indices_mappings}, organ_indices_json_file, indent=4)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='moosez',
-    version="3.0.25",
+    version="3.0.26",
     author='Lalith Kumar Shiyam Sundar | Sebastian Gutschmayer | Manuel Pires',
     author_email='Lalith.shiyamsundar@meduniwien.ac.at',
     description='An AI-inference engine for 3D clinical and preclinical whole-body segmentation tasks',


### PR DESCRIPTION
models.py
- adjust organ_indices_to_json to dynamically leave out organs with no SNOMED mapping.

setup.py
- raised moosez version to 3.0.26

This is related to #207 and fixes it. 