### PR TITLE
Fix unicode encoding error on Windows

### DIFF
--- a/moosez/system.py
+++ b/moosez/system.py
@@ -47,6 +47,9 @@ class OutputManager:
         self.logger = None
         self.nnunet_log_filename = os.devnull
 
+        # On Windows, the console encoding may not be UTF-8, which can cause issues with certain characters
+        self.sanitize_console_encoding = self.console.encoding.lower() not in ['utf-8', 'utf8']
+
     def create_file_progress_bar(self):
         progress_bar = Progress(TextColumn("[bold blue]{task.description}"), BarColumn(bar_width=None),
                                 "[progress.percentage]{task.percentage:>3.0f}%", "•", FileSizeColumn(),
@@ -98,6 +101,11 @@ class OutputManager:
     def console_update(self, text: Union[str, RenderableType]):
         if isinstance(text, str):
             text = Text.from_ansi(text)
+
+        if self.sanitize_console_encoding and isinstance(text, Text):
+            # Ensure the text can be represented in the console by robust encoding and decoding (ignoring invalid characters)
+            text = Text(text.plain.encode(self.console.encoding, "ignore").decode(self.console.encoding))
+
         self.console.print(text)
 
     def spinner_update(self, text: str):


### PR DESCRIPTION
On Windows in Python-3.12, moose fails to segment anything due to this unicode encoding error:

```
Running moosez for model: clin_ct_body_composition
     __  _______  ____  ________  ____  ___ ___
    /  |/  / __ \/ __ \/ __/ __/ |_  / <  // _ \
   / /|_/ / /_/ / /_/ /\ \/ _/  _/_ <_ / // // /
  /_/  /_/\____/\____/___/___/ /____(_)_(_)___/
 A part of the ENHANCE community. Join us at www.enhance.pet to build the
future of PET imaging together.
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\andra\AppData\Local\slicer.org\3D Slicer 5.9.0-2025-10-22\lib\Python\Scripts\moosez.exe\__main__.py", line 7, in <module>
  File "C:\Users\andra\AppData\Local\slicer.org\3D Slicer 5.9.0-2025-10-22\lib\Python\Lib\site-packages\moosez\moosez.py", line 156, in main
    output_manager.display_authors()
  File "C:\Users\andra\AppData\Local\slicer.org\3D Slicer 5.9.0-2025-10-22\lib\Python\Lib\site-packages\moosez\system.py", line 162, in display_authors
    self.console_update(f'{ANSI_VIOLET} {emoji.emojize(":desktop_computer:")}  AUTHORS:{ANSI_RESET}')
  File "C:\Users\andra\AppData\Local\slicer.org\3D Slicer 5.9.0-2025-10-22\lib\Python\Lib\site-packages\moosez\system.py", line 101, in console_update
    self.console.print(text)
  File "C:\Users\andra\AppData\Local\slicer.org\3D Slicer 5.9.0-2025-10-22\lib\Python\Lib\site-packages\rich\console.py", line 1697, in print
    with self:
         ^^^^
  File "C:\Users\andra\AppData\Local\slicer.org\3D Slicer 5.9.0-2025-10-22\lib\Python\Lib\site-packages\rich\console.py", line 870, in __exit__
    self._exit_buffer()
  File "C:\Users\andra\AppData\Local\slicer.org\3D Slicer 5.9.0-2025-10-22\lib\Python\Lib\site-packages\rich\console.py", line 826, in _exit_buffer
    self._check_buffer()
  File "C:\Users\andra\AppData\Local\slicer.org\3D Slicer 5.9.0-2025-10-22\lib\Python\Lib\site-packages\rich\console.py", line 2038, in _check_buffer
    self._write_buffer()
  File "C:\Users\andra\AppData\Local\slicer.org\3D Slicer 5.9.0-2025-10-22\lib\Python\Lib\site-packages\rich\console.py", line 2074, in _write_buffer
    legacy_windows_render(buffer, LegacyWindowsTerm(self.file))
  File "C:\Users\andra\AppData\Local\slicer.org\3D Slicer 5.9.0-2025-10-22\lib\Python\Lib\site-packages\rich\_windows_renderer.py", line 17, in legacy_windows_render
    term.write_styled(text, style)
  File "C:\Users\andra\AppData\Local\slicer.org\3D Slicer 5.9.0-2025-10-22\lib\Python\Lib\site-packages\rich\_win32_console.py", line 441, in write_styled
    self.write_text(text)
  File "C:\Users\andra\AppData\Local\slicer.org\3D Slicer 5.9.0-2025-10-22\lib\Python\Lib\site-packages\rich\_win32_console.py", line 402, in write_text
    self.write(text)
  File "C:\Users\andra\AppData\Local\slicer.org\3D Slicer 5.9.0-2025-10-22\lib\Python\Lib\site-packages\colorama\ansitowin32.py", line 47, in write
    self.__convertor.write(text)
  File "C:\Users\andra\AppData\Local\slicer.org\3D Slicer 5.9.0-2025-10-22\lib\Python\Lib\site-packages\colorama\ansitowin32.py", line 177, in write
    self.write_and_convert(text)
  File "C:\Users\andra\AppData\Local\slicer.org\3D Slicer 5.9.0-2025-10-22\lib\Python\Lib\site-packages\colorama\ansitowin32.py", line 205, in write_and_convert
    self.write_plain_text(text, cursor, len(text))
  File "C:\Users\andra\AppData\Local\slicer.org\3D Slicer 5.9.0-2025-10-22\lib\Python\Lib\site-packages\colorama\ansitowin32.py", line 210, in write_plain_text
    self.wrapped.write(text[start:end])
  File "C:\Users\andra\AppData\Local\slicer.org\3D Slicer 5.9.0-2025-10-22\lib\Python\Lib\site-packages\colorama\ansitowin32.py", line 47, in write
    self.__convertor.write(text)
  File "C:\Users\andra\AppData\Local\slicer.org\3D Slicer 5.9.0-2025-10-22\lib\Python\Lib\site-packages\colorama\ansitowin32.py", line 177, in write
    self.write_and_convert(text)
  File "C:\Users\andra\AppData\Local\slicer.org\3D Slicer 5.9.0-2025-10-22\lib\Python\Lib\site-packages\colorama\ansitowin32.py", line 205, in write_and_convert
    self.write_plain_text(text, cursor, len(text))
  File "C:\Users\andra\AppData\Local\slicer.org\3D Slicer 5.9.0-2025-10-22\lib\Python\Lib\site-packages\colorama\ansitowin32.py", line 210, in write_plain_text
    self.wrapped.write(text[start:end])
  File "C:\Users\andra\AppData\Local\slicer.org\3D Slicer 5.9.0-2025-10-22\lib\Python\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode characters in position 1-2: character maps to <undefined>
```

Solved by ignoring all characters that the console encoding cannot represent if the console does not use utf8 encoding (e.g., console on most Windows systems).
