### PR TITLE
Python API now standardizes images to RAS 

### DIFF
--- a/moosez/image_processing.py
+++ b/moosez/image_processing.py
@@ -220,8 +220,6 @@ def image_read(image_path: str) -> SimpleITK.Image:
     except RuntimeError:
         with tempfile.TemporaryDirectory() as tmpdir:
             file_tmp_path = os.path.join(tmpdir, "non_orthonormal.nii.gz")
-            print(image_path)
-            print(file_tmp_path)
             image_nibabel = nibabel.load(image_path)
             nibabel.save(nibabel.Nifti1Image(image_nibabel.get_fdata(), image_nibabel.get_qform()), file_tmp_path)
             image = SimpleITK.ReadImage(file_tmp_path)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='moosez',
-    version="3.1.1",
+    version="3.1.2",
     author='Lalith Kumar Shiyam Sundar | Sebastian Gutschmayer | Manuel Pires',
     author_email='Lalith.shiyamsundar@meduniwien.ac.at',
     description='An AI-inference engine for 3D clinical and preclinical whole-body segmentation tasks',


### PR DESCRIPTION
Python API now standardises images to RAS for inference when a path is provided as input.

image_processing.py
- removed two unneeded prints

setup.py
- elevated version to `3.1.2` (was `3.1.1`)

moosez.py
- adjusted `moose()` so that when the `input_data` is a string, the image is read, reoriented, and the original orientation code is stored. The original orientation is then restored for the segmentation to comply with the original image.
- removed redundant comments